### PR TITLE
Vim Hg tags have dots as separator

### DIFF
--- a/vim/meta.yaml
+++ b/vim/meta.yaml
@@ -7,8 +7,8 @@ source:
     #fn: vim-7.4.tar.bz2                                 [not win]
     #url: ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2 [not win]
     hg_url: https://vim.googlecode.com/hg/
-    hg_tag: v7-4-453                                    [win]
-    hg_tag: v7-4-493                                    [not win]
+    hg_tag: v7.4.453                                    [win]
+    hg_tag: v7.4.493                                    [not win]
 
 requirements:
     build:


### PR DESCRIPTION
I was able to successfully build vim on Windows after making this change. See issue #395.
